### PR TITLE
Update openredirex.py

### DIFF
--- a/openredirex.py
+++ b/openredirex.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import asyncio
 import aiohttp
 import os


### PR DESCRIPTION
We could directly add this #!/usr/bin/env python3 on the openredirex.py file and  and shorten the setup time, as the file would be recognised as a python3 file by default.