### PR TITLE
Updated Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
 ```
 $ git clone https://github.com/devanshbatham/OpenRedireX
 $ cd OpenRedireX
-$ python3 -m venv env
-$ source env/bin/activate
 Note : The "FUZZ" is important and the url must be in double qoutes ! 
 $ python3.7 openredirex.py -u "https://vulnerable.com/?url=FUZZ" -p payloads.txt --keyword FUZZ
 ```


### PR DESCRIPTION
Hey in the last commit i suggested a change in the code to include links to a python interpreter so as to easily run without extra setup headaches. I installed the tool on a new machine and noticed that the install guide was yet to be updated. If the code already points to a python 3 interpreter i don't think we will need to create virtual environments for this tool. Let's go with the new install guide, i have tested and it is working normally without issues. Saves some time and brain cells don't you think. :+1: 
PS: Not a Hactoberfest Spam Pull :sweat_smile: